### PR TITLE
fix yeti crab

### DIFF
--- a/js/BazaarPatcher.js
+++ b/js/BazaarPatcher.js
@@ -7,6 +7,9 @@ export class BazaarPatcher {
         if(items["Pistol Sword"].text[1].match(/^When you use an Ammo item, deal .* damage\.$/i)) {
             items["Pistol Sword"].text[1] = "When you use an Ammo item, deal damage.";
         }
+        if(items["Epicurean Chocolate"]) {
+            items["Epicurean Chocolate"].text=[items["Epicurean Chocolate"].text[0]];
+        }
         if(!items["Sleeping Potion"].tags.includes("Ammo")) {
             items["Sleeping Potion"].tags.push("Ammo");
         }

--- a/js/Item.js
+++ b/js/Item.js
@@ -1140,7 +1140,7 @@ export class Item {
 
         //Adjacent Weapons permanently gain ( +1 » +2 » +3 » +4 ) Damage. from Epicurean Chocolate
         //Adjacent (Weapons|Tool items|Tools) gain ( 5 » 10 ) Damage for the fight.
-        damageRegex = /^(this and)?\s*Adjacent ([^\s]+)s?\s*(?:items)?\s*(?:permanently )?(gains? )?(\([^)]+\)|\d+) ([^\s]+)(?: chance)?(?: for the fight)?\.?/i;
+        damageRegex = /^(this and)?\s*Adjacent ([^\s]+)s?\s*(?:items)?\s*(?:permanently )?(gains? )?(\([^)]+\)|\d+) ([^\s]+)(?: chance)?(?: for the fight)?\./i;
         match = text.match(damageRegex);
         if(match) {
             const itemType = match[2];

--- a/js/ItemFunction.js
+++ b/js/ItemFunction.js
@@ -6,7 +6,7 @@ import { BazaarPatcher } from "./BazaarPatcher.js";
 export class ItemFunction {
     static items = new Map();
     static doNothingItemNames = ["Bar of Gold","Super Syrup","Signet Ring", "Bag of Jewels","Disguise","Bulky Package","Bootstraps","Business Card",
-        "Epicurean Chocolate","Spare Change","Pelt","Candy Mail","Machine Learning","Chocoholic","Like Clockwork","Upgrade Hammer", "Sifting Pan",
+        "Spare Change","Pelt","Candy Mail","Machine Learning","Chocoholic","Like Clockwork","Upgrade Hammer", "Sifting Pan",
     "Vending Machine","Piggy Bank","Cash Register","Cargo Shorts","Alembic","The Tome of Yyahan","Catalyst","Chunk of Lead","Chunk of Gold", "Catalyst"];
     static setupItems() {
         ItemFunction.doNothingItemNames.forEach(itemName => {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix Epicurean Chocolate's adjacent damage effect by correcting the damageRegex and gain function to pass the proper source context, updating the Bazaar patch to trim its description, and removing it from the do-nothing item list