### PR TITLE
fix editing items in backpacks

### DIFF
--- a/js/Board.js
+++ b/js/Board.js
@@ -108,7 +108,7 @@ class Board {
         return this._follow;
     }
     get backpackParent() {
-        let foundBoard = null;
+        let foundBoard = undefined;
         Board.boards.forEach(board => {
             if (board.backpack === this) {
                 foundBoard = board;
@@ -169,7 +169,7 @@ class Board {
             this.createBackpackElement();
             this.createBoardControls();
         }
-        if(this.isBackpack) {
+        if(!this.isBackpack) {
             this.createHealthElement();
             this.createSkillsElement();
             this.createGoldElement();
@@ -246,7 +246,7 @@ class Board {
                 this.winRateElement.style.display = "none";
             }
         }
-        if(this.boardId!='backpack' && this.boardId!='tb') {
+        if(!this.isBackpack) {
             this.updateGoldElement();
             this.updateIncomeElement();
             this.updatePrestigeElement();


### PR DESCRIPTION
## Summary by Sourcery

Fix editing items in backpacks by correcting backpack detection logic and restricting element creation and updates to non-backpack boards.

Bug Fixes:
- Initialize foundBoard as undefined instead of null for accurate parent board lookup
- Invert isBackpack checks to only create health, skills, and gold elements for non-backpack boards
- Replace boardId string comparisons with isBackpack flag in update methods to simplify conditional logic