### PR TITLE
Fix: Correct Honing Steel and Lumboars item effects

### DIFF
--- a/js/Item.js
+++ b/js/Item.js
@@ -1088,7 +1088,7 @@ export class Item {
         //Your weapons gain ( 2 » 4 » 6 » 8 ) damage for the fight.
         //your Shield items gain (  5  » 10  » 15   ) Shield for the fight
         
-        // Regex spécifique pour Lumboars et patterns similaires
+        // Specific regex for Lumboars and similar patterns
         let lumboarsRegex = /^Your Weapons gain \(([^)]+)\) Damage for the fight$/i;
         let lumboarsMatch = text.match(lumboarsRegex);
         if(lumboarsMatch) {
@@ -1116,7 +1116,7 @@ export class Item {
                     this.board.items.forEach(item => {
                         if(other && item.id == this.id) return;
                         if(tagToMatch=='Item' || item.tags.includes(tagToMatch)) {
-                            item.gain(gainAmount,whatToGain,this);
+                            item.gain(gainAmount, whatToGain, this);
                         }
                     });
                 });


### PR DESCRIPTION
- Fix Honing Steel to boost only adjacent weapon to the right instead of all weapons to the right
- Fix Lumboars to properly boost all weapons with damage for the fight
- Add specific regex for 'weapon to the right' pattern in Honing Steel
- Add specific regex for Lumboars weapon damage boost pattern
- Remove incorrect logic that was adding damage to the item itself instead of target weapons

## Summary by Sourcery

Fix detection and application of Honing Steel and Lumboars item effects by refining regex patterns, applying damage boosts correctly to target weapons, and removing incorrect self-targeting logic

Bug Fixes:
- Correct Honing Steel to only boost the adjacent weapon on the right
- Fix Lumboars to correctly boost all weapons with damage
- Remove logic that was erroneously adding damage to the item itself instead of target weapons

Enhancements:
- Add specific regex patterns for detecting Honing Steel and Lumboars effects