### PR TITLE
honing steel fix and others

### DIFF
--- a/js/Item.js
+++ b/js/Item.js
@@ -5161,24 +5161,28 @@ export class Item {
         }
 
         //Burn items to the right of this gain ( 1 » 2 » 3 » 4 ) Burn for the fight
-
-        regex = /^(This and )?(?:the )?([^\s]+)(?: item)?s? to the right of this gains? (\([^)]+\)|\+?\d+) ([^\s]+).*/i;
+        regex = /^(This and )?(?:the )?([^\s]+)(?: item)?(s)? to the right of this gains? (\([^)]+\)|\+?\d+) ([^\s]+)(?: for the fight)?\.?/i;
         match = text.match(regex);
-
         if(match) {
-            const thisAnd = match[1] ? true : false;
+            const thisAnd = !!match[1];
             const tagToMatch = Item.getTagFromText(match[2]);
-            const gainAmount = getRarityValue(match[3], this.rarity);
-            const whatToGain = match[4].toLowerCase();
+            const plural = !!match[3] || match[2][match[2].length-1]=='s';
+            const gainAmount = getRarityValue(match[4], this.rarity);
+            const whatToGain = match[5].toLowerCase();
             return () => {
                 if(thisAnd) {
                     this.gain(gainAmount,whatToGain,this);
                 }
-                this.board.items.filter(item => item.startIndex>this.startIndex && item.tags.includes(tagToMatch)).forEach(item => {
-                    item.gain(gainAmount,whatToGain,this);
-                });
+                if(plural) {
+                    this.board.items.filter(item => item.startIndex>this.startIndex && item.tags.includes(tagToMatch)).forEach(item => {
+                        item.gain(gainAmount,whatToGain,this);
+                    });
+                } else {
+                    this.getItemToTheRight().gain(gainAmount,whatToGain,this);
+                }
             };
         }
+
         //This has double value in combat.
         regex = /^This has double value in combat\.?$/i;
         match = text.match(regex);

--- a/js/TextMatcher.js
+++ b/js/TextMatcher.js
@@ -44,6 +44,33 @@ export class TextMatcher {
     static matchers = [];
     static undoableFunctions = [
     {
+        regex: /^This has double (damage|poison|burn|shield|heal|ammo|charge|regen)\.?$/i,
+        func: (item, match)=>{
+            let whatToGain = match[1].toLowerCase();
+            if(whatToGain=="ammo") {
+                whatToGain = "maxAmmo";
+            }
+          
+            const doIt = () => {
+                item[whatToGain+"pauseChanged"] = true;
+                const oldMultiplier = item[whatToGain+"_multiplier"];
+                item[whatToGain+"_multiplier"] =1;
+                item.gain(item[whatToGain],whatToGain);
+                item[whatToGain+"pauseChanged"] = false;
+                item[whatToGain+"_multiplier"] = oldMultiplier*2;
+            }
+            const undoIt = () => {
+                item[whatToGain+"pauseChanged"] = true;
+                const oldMultiplier = item[whatToGain+"_multiplier"];
+                item[whatToGain+"_multiplier"] = 1;
+                item.gain(-item[whatToGain],whatToGain);
+                item[whatToGain+"pauseChanged"] = false;
+                item[whatToGain+"_multiplier"] = oldMultiplier/2;
+            };
+            return {doIt, undoIt};
+        },
+    },
+    {
         regex: /^(this item's|its) cooldown is reduced by (\([^)]+\)|[\d\.]+)%?( seconds?)?\.?$/i,
         func: (item, match)=>{
             const cooldownReduction = getRarityValue(match[2], item.rarity);


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new undoable matcher for doubling stats and correct context references in existing matchers, while enhancing regex parsing and lookup logic for conditional triggers and item gains.

New Features:
- Add an undoable matcher for "This has double X" to apply and reverse doubling of various stats

Bug Fixes:
- Fix binding issues in multiple TextMatcher undoable functions by using the passed item parameter instead of 'this'

Enhancements:
- Refactor the slowed/hasted/frozen condition matcher to cache and reuse the item type
- Improve the right-of-this gain matcher to handle singular vs plural items and optional "for the fight" suffix
- Use Array.find in getUndoableFunctionFromText for early exit once a matcher is found