### PR TITLE
fix wrecking ball and keg

### DIFF
--- a/js/Item.js
+++ b/js/Item.js
@@ -1046,9 +1046,12 @@ export class Item {
     getWeaponTriggerFunction(text) {
         let match;
 
+        
+
         //Deal damage equal to your enemy's max health
         //Deal damage equal to ( 20% » 30% ) of your enemy's Max Health.
-        let damageRegex = /Deal damage equal to \(?([^)]+)?\)?(?: of )?(your|your enemy's|the enemy's) Max Health\.?$/i;
+        //Deal Damage equal to (30%/40%) of an enemy's Max Health. from Wrecking Ball, Powder Keg
+        let damageRegex = /Deal damage equal to \(?([^)]+)?\)?(?: of )?(your|your enemy's|the enemy's|an enemy's) Max Health\.?$/i;
         match = text.match(damageRegex);
 
         if(match) {

--- a/js/TextMatcher.js
+++ b/js/TextMatcher.js
@@ -1944,3 +1944,21 @@ TextMatcher.matchers.push({
         return ()=>{};
     }
 });
+
+//When this starts Flying ... from Wrecking Ball
+TextMatcher.matchers.push({
+    regex: /^When this (starts|stops) Flying, (.*)$/i,
+    func: (item, match)=>{
+        const f = item.getTriggerFunctionFromText(match[2], item);
+        const isStart = match[1]=='starts';
+        item.flyingChanged((newFlying,oldFlying)=>{
+            if(isStart&&newFlying&&!oldFlying) {
+                f(item);
+            }
+            if(!isStart&&!newFlying&&oldFlying) {
+                f(item);
+            }
+        });
+        return ()=>{};
+    }
+});


### PR DESCRIPTION
## Summary by Sourcery

Add support for Flying trigger text from Wrecking Ball and update the weapon trigger regex to correctly match damage based on an enemy’s max health for cards like Powder Keg.

Enhancements:
- Add matcher for "When this starts/stops Flying" triggers in TextMatcher
- Extend the damageRegex in Item.getWeaponTriggerFunction to include "an enemy's Max Health"