### PR TITLE
fixes haunting flight skill adds items start/stop flying

### DIFF
--- a/js/Item.js
+++ b/js/Item.js
@@ -1061,8 +1061,6 @@ export class Item {
                 this.board.player.maxHealthChanged((newMaxHealth,oldMaxHealth)=>{
                     this.gain(newMaxHealth*dmgMultiplier/100 - oldMaxHealth*dmgMultiplier/100,'damage');
                 });
-
-
             } else {
                 this.gain(this.board.player.hostileTarget.maxHealth*dmgMultiplier/100,'damage');
                 this.board.player.hostileTarget.maxHealthChanged((newMaxHealth,oldMaxHealth)=>{
@@ -1070,13 +1068,9 @@ export class Item {
                 });
             }            
 
-
             return () => {
                 this.dealDamage(this.damage);
             };
-
-
-
         }
         //Reduce its cooldown by 5% for the fight.
         damageRegex = /Reduce its cooldown by (\([^\)]+\)|\d+%) for the fight\.?/i;

--- a/js/TextMatcher.js
+++ b/js/TextMatcher.js
@@ -1962,3 +1962,20 @@ TextMatcher.matchers.push({
         return ()=>{};
     }
 });
+
+//"(1/2/3) Small item(s) start Flying." from Haunting Flight
+TextMatcher.matchers.push({
+    regex: /^(\([^)]+\)|\d+) (\w+) item\(?s?\)? (start|stop)s? Flying\.?$/i,
+    func: (item, match)=>{
+        const numItems = getRarityValue(match[1], item.rarity);
+        const tag = Item.getTagFromText(match[2]);
+        const isStart = match[3].startsWith('start');
+        
+        return ()=>{
+            const items = item.board.items.filter(i=>i.tags.includes(tag) && i.flying!=isStart);
+            item.pickRandom(items,numItems).forEach(i=>{
+                i.flying = isStart;
+            });
+        };
+    }
+});


### PR DESCRIPTION
## Summary by Sourcery

Add support for the Haunting Flight skill to toggle flying states on items and clean up minor whitespace in Item.js.

New Features:
- Add a TextMatcher regex to parse Haunting Flight messages that start or stop items flying and apply the flying state to randomly picked items based on rarity.

Enhancements:
- Remove redundant blank lines around damage and cooldown logic in Item.js for tidier formatting.