### PR TITLE
fix cargo shorts/bob

### DIFF
--- a/js/Item.js
+++ b/js/Item.js
@@ -2825,6 +2825,13 @@ export class Item {
                     case "over-heal":
                         this.board.player.overhealTriggers.set(this.id, triggerFunctionFromText);
                         return ()=>{};
+                    case "heal with an item":
+                        this.board.player.healTriggers.set(this.id+"_"+triggerFunctionFromText.text, (item) => {
+                            if(!item.isSkill) {
+                                triggerFunctionFromText(item);
+                            }
+                        });
+                        return ()=>{};
                     case "heal":
                         this.board.player.healTriggers.set(this.id+"_"+triggerFunctionFromText.text, triggerFunctionFromText);
                         return ()=>{};
@@ -4706,11 +4713,18 @@ export class Item {
             };
         }
 
-        //This has +1 Multicast for each of its Types.
-        regex = /^\s*This has \+1 Multicast for each of its Types\.?/i;
+        //Cargo Shorts
+        regex = /^\s*This has \+1 Multicast for each (?:of it'?s types|type this has)\.?/i;
         match = text.match(regex);
         if(match) {
-            this.gain(this.tags.filter(t=>Board.uniqueTypeTags.includes(t)).length,'multicast');
+            let typeCount = this.tags.filter(t=>Board.uniqueTypeTags.includes(t)).length;
+            this.gain(typeCount,'multicast');
+
+            this.typesChanged(()=>{
+                const newTypeCount = this.tags.filter(t=>Board.uniqueTypeTags.includes(t)).length;
+                this.gain(newTypeCount-typeCount,'multicast');
+                typeCount = newTypeCount;
+            });
             return () => {};
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a conditional heal trigger for items and enhance Cargo Shorts to correctly handle dynamic type-based multicast and alternative wording

New Features:
- Add a "heal with an item" trigger that only fires on non-skill items

Enhancements:
- Broaden the Cargo Shorts regex to match alternate phrasing of type-based multicast
- Make Cargo Shorts dynamically grant multicast when the item’s types change